### PR TITLE
Hardaway Experience Report Submission

### DIFF
--- a/assignment_submission/experience_report/HardawayGrant_PPPP_Experience.md
+++ b/assignment_submission/experience_report/HardawayGrant_PPPP_Experience.md
@@ -1,0 +1,38 @@
+Grant Hardaway  
+INF385T - Peer Production  
+
+# Peer Production Participation Project: Experience Report
+
+## Introduction
+For this project, I participated in the peer production community of the collaborative music and film database [Rate Your Music (RYM)]( https://rateyourmusic.com/). As stated in my 
+community identification paper, my goal for this project was to add and improve entries for Austin musicians and their albums. Over the course of a month, I was able to successfully 
+contribute multiple additions to the database.
+
+## Preparation  
+Before I could contribute to RYM, I needed to set up a free account and research what artists or albums were missing from their catalog. The account set-up was simple and took me less 
+than five minutes. To check what artists or albums were missing from the catalog, I searched Austin band names in the webpage’s search bar. If the artist did not appear in the search 
+results, RYM would present a link at the bottom of the page to add an artist. Through this process, I identified three Austin musicians that did not have any record on RYM.
+
+To prepare for creating a new entry, I looked over RYM’s [wiki](https://rateyourmusic.com/wiki/Music:Add+an+artist) on adding artist profiles to the database. Then, I gathered reliable 
+sources on the artists through bandcamp, Facebook, and/or their own personal webpage. Once I felt like I was adequately prepared, I would begin an entry.
+
+## Participation
+The “Add artist” page is initially overwhelming with jargon such as “artist ID links” prominently featured in the descriptions of fields and some optional fields that are unnecessary 
+for smaller artists. I regularly referenced RYM’s [wiki](https://rateyourmusic.com/wiki/Music:Artist+profiles) on artist profiles to help me navigate the page’s interface. I would then 
+enter in all of the relevant information (e.g. artist name, band members, search hints, sources of information, etc.) and submit my entry for review.
+
+## Submission Moderation
+Submission review consists of an individual appraising my entry and then voting “yes” or “no” on its accuracy and adherence to the database’s guidelines. The reviewer checks the 
+sources provided in the entry’s meta-comments to verify that the information for the artist is correct. Before voting, a reviewer can add a comment on the submission discussion page to 
+suggest a correction. A submission would then be approved either when three community members (who have a standard account like myself) vote “yes” or a single moderator votes “yes”.
+
+For my first profile submission of the artist [Little Mazarn](https://rateyourmusic.com/artist/little-mazarn), a moderator named “jshopa” identified a couple of errors that needed to 
+be corrected before the profile could be approved. For instance, I had listed the artist’s place of birth as Austin, but, as the moderator pointed out, my sources only indicated that 
+the artist currently lived in Austin. Additionally, I needed to add a release, credit, or gig to her page before the artist could be deemed relevant enough to be added to the database. 
+Once I had made the requested changes, the moderator approved my entry. The learning curve of this first entry helped my submissions for the other two artist profiles ([Duncan 
+Fellows](https://rateyourmusic.com/artist/duncan-fellows) and [Big Wy’s Brass Band](https://rateyourmusic.com/artist/big-wys-brass-band)) to go smoothly.
+
+## Conclusion
+My experience on RYM was largely positive. As a regular user of the database, it was fascinating to look behind the scenes on how the massive collection is created and moderated. I 
+plan on continuing to contribute to RYM in the future and help small Austin musicians have a record of their work on the database.
+


### PR DESCRIPTION
Erroneous commits pre-dated the creation of the experience_report folder. Whenever I had the cherry-pick branch created before my erroneous commits, the experience_report would not exist. So instead of sending a bunch of extra commits, I just added the experience report to the assignment_submission folder.